### PR TITLE
Added continue option for breaks

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -24,15 +24,16 @@ func NewChoiceModel(choices []string) ChoiceModel {
 }
 
 type KeyMap struct {
-	Start   key.Binding
-	Stop    key.Binding
-	Up      key.Binding
-	Down    key.Binding
-	Enter   key.Binding
-	Init    key.Binding
-	Confirm key.Binding
-	Reset   key.Binding
-	Quit    key.Binding
+	Start    key.Binding
+	Stop     key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Enter    key.Binding
+	Init     key.Binding
+	Confirm  key.Binding
+	Continue key.Binding
+	Reset    key.Binding
+	Quit     key.Binding
 }
 
 func NewKeyMap() KeyMap {
@@ -65,6 +66,10 @@ func NewKeyMap() KeyMap {
 			key.WithKeys("c"),
 			key.WithHelp("c", "confirm"),
 		),
+		Continue: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "continue"),
+		),
 		Reset: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "reset"),
@@ -77,6 +82,7 @@ func NewKeyMap() KeyMap {
 
 	km.Start.SetEnabled(false)
 	km.Stop.SetEnabled(false)
+	km.Continue.SetEnabled(false)
 	km.Reset.SetEnabled(false)
 
 	return km

--- a/model/update.go
+++ b/model/update.go
@@ -12,8 +12,8 @@ func HandleUpdate(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 		return HandleTimerTickMsg(m, msg)
 	case timer.StartStopMsg:
 		return HandleTimerStartStopMsg(m, msg)
-    case timer.TimeoutMsg:
-        return HandleTimerTimeout(m)
+	case timer.TimeoutMsg:
+		return HandleTimerTimeout(m)
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.Quit):
@@ -26,8 +26,10 @@ func HandleUpdate(msg tea.Msg, m Model) (tea.Model, tea.Cmd) {
 			return HandleEnter(m)
 		case key.Matches(msg, m.KeyMap.Confirm):
 			return HandleConfirm(m)
+		case key.Matches(msg, m.KeyMap.Continue):
+			return HandleContinue(m)
 		case key.Matches(msg, m.KeyMap.Start, m.KeyMap.Stop):
-            return HandleStartStop(m)
+			return HandleStartStop(m)
 		}
 	}
 

--- a/model/view.go
+++ b/model/view.go
@@ -135,6 +135,7 @@ func HelpView(m Model) string {
 		m.KeyMap.Confirm,
 		m.KeyMap.Start,
 		m.KeyMap.Stop,
+		m.KeyMap.Continue,
 		m.KeyMap.Reset,
 		m.KeyMap.Quit,
 	})


### PR DESCRIPTION
Added a new keybind (c - continue) while on a break to skip the break timer and continue with the next work session.
Some other minor changes include a reformat (some whitespace changes from go fmt) and renaming one variable in HandleTimerTickMsg for consistency